### PR TITLE
fix: move pnpm settings out of .npmrc to silence npm 11 warnings

### DIFF
--- a/20/Dockerfile
+++ b/20/Dockerfile
@@ -20,13 +20,26 @@ RUN adduser -D -u 1337 kool && deluser --remove-home node \
         make \
         zlib-dev \
     && npm install -g pnpm \
+    # pnpm global settings live in ~/.config/pnpm/rc so npm does not warn on unknown keys in ~/.npmrc (npm 11+)
+    && mkdir -p /root/.config/pnpm /home/kool/.config/pnpm \
+    && printf '%s\n' \
+        'store-dir=/root/.pnpm-store' \
+        'package-import-method=copy' \
+        'shamefully-hoist=true' \
+        'scripts-prepend-node-path=true' \
+        > /root/.config/pnpm/rc \
+    && printf '%s\n' \
+        'store-dir=/home/kool/.pnpm-store' \
+        'package-import-method=copy' \
+        'shamefully-hoist=true' \
+        'scripts-prepend-node-path=true' \
+        > /home/kool/.config/pnpm/rc \
+    && chown -R kool:kool /home/kool/.config \
     && rm -rf rm -rf /root/.npm/* \
     # dockerize
     && curl -L https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-alpine-linux-amd64-v0.6.1.tar.gz | tar xz \
     && mv dockerize /usr/local/bin/dockerize
 
-COPY root-npmrc /root/.npmrc
-COPY --chown=kool:kool kool-npmrc /home/kool/.npmrc
 COPY entrypoint /entrypoint
 
 RUN chmod +x /entrypoint

--- a/20/kool-npmrc
+++ b/20/kool-npmrc
@@ -1,4 +1,0 @@
-scripts-prepend-node-path=true
-package-import-method=copy
-shamefully-hoist=true
-store-dir=/home/kool/.pnpm-store

--- a/20/root-npmrc
+++ b/20/root-npmrc
@@ -1,4 +1,0 @@
-scripts-prepend-node-path=true
-package-import-method=copy
-shamefully-hoist=true
-store-dir=/root/.pnpm-store

--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -20,13 +20,26 @@ RUN adduser -D -u 1337 kool && deluser --remove-home node \
         make \
         zlib-dev \
     && npm install -g pnpm \
+    # pnpm global settings live in ~/.config/pnpm/rc so npm does not warn on unknown keys in ~/.npmrc (npm 11+)
+    && mkdir -p /root/.config/pnpm /home/kool/.config/pnpm \
+    && printf '%s\n' \
+        'store-dir=/root/.pnpm-store' \
+        'package-import-method=copy' \
+        'shamefully-hoist=true' \
+        'scripts-prepend-node-path=true' \
+        > /root/.config/pnpm/rc \
+    && printf '%s\n' \
+        'store-dir=/home/kool/.pnpm-store' \
+        'package-import-method=copy' \
+        'shamefully-hoist=true' \
+        'scripts-prepend-node-path=true' \
+        > /home/kool/.config/pnpm/rc \
+    && chown -R kool:kool /home/kool/.config \
     && rm -rf rm -rf /root/.npm/* \
     # dockerize
     && curl -L https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-alpine-linux-amd64-v0.6.1.tar.gz | tar xz \
     && mv dockerize /usr/local/bin/dockerize
 
-COPY root-npmrc /root/.npmrc
-COPY --chown=kool:kool kool-npmrc /home/kool/.npmrc
 COPY entrypoint /entrypoint
 
 RUN chmod +x /entrypoint

--- a/22/kool-npmrc
+++ b/22/kool-npmrc
@@ -1,4 +1,0 @@
-scripts-prepend-node-path=true
-package-import-method=copy
-shamefully-hoist=true
-store-dir=/home/kool/.pnpm-store

--- a/22/root-npmrc
+++ b/22/root-npmrc
@@ -1,4 +1,0 @@
-scripts-prepend-node-path=true
-package-import-method=copy
-shamefully-hoist=true
-store-dir=/root/.pnpm-store

--- a/24/Dockerfile
+++ b/24/Dockerfile
@@ -20,13 +20,26 @@ RUN adduser -D -u 1337 kool && deluser --remove-home node \
         make \
         zlib-dev \
     && npm install -g pnpm \
+    # pnpm global settings live in ~/.config/pnpm/rc so npm does not warn on unknown keys in ~/.npmrc (npm 11+)
+    && mkdir -p /root/.config/pnpm /home/kool/.config/pnpm \
+    && printf '%s\n' \
+        'store-dir=/root/.pnpm-store' \
+        'package-import-method=copy' \
+        'shamefully-hoist=true' \
+        'scripts-prepend-node-path=true' \
+        > /root/.config/pnpm/rc \
+    && printf '%s\n' \
+        'store-dir=/home/kool/.pnpm-store' \
+        'package-import-method=copy' \
+        'shamefully-hoist=true' \
+        'scripts-prepend-node-path=true' \
+        > /home/kool/.config/pnpm/rc \
+    && chown -R kool:kool /home/kool/.config \
     && rm -rf rm -rf /root/.npm/* \
     # dockerize
     && curl -L https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-alpine-linux-amd64-v0.6.1.tar.gz | tar xz \
     && mv dockerize /usr/local/bin/dockerize
 
-COPY root-npmrc /root/.npmrc
-COPY --chown=kool:kool kool-npmrc /home/kool/.npmrc
 COPY entrypoint /entrypoint
 
 RUN chmod +x /entrypoint

--- a/24/kool-npmrc
+++ b/24/kool-npmrc
@@ -1,4 +1,0 @@
-scripts-prepend-node-path=true
-package-import-method=copy
-shamefully-hoist=true
-store-dir=/home/kool/.pnpm-store

--- a/24/root-npmrc
+++ b/24/root-npmrc
@@ -1,4 +1,0 @@
-scripts-prepend-node-path=true
-package-import-method=copy
-shamefully-hoist=true
-store-dir=/root/.pnpm-store

--- a/fwd-template.json
+++ b/fwd-template.json
@@ -15,14 +15,6 @@
                 {
                     "name": "entrypoint",
                     "path": "template/entrypoint"
-                },
-                {
-                    "name": "kool-npmrc",
-                    "path": "template/kool-npmrc"
-                },
-                {
-                    "name": "root-npmrc",
-                    "path": "template/root-npmrc"
                 }
             ]
         },
@@ -40,14 +32,6 @@
                 {
                     "name": "entrypoint",
                     "path": "template/entrypoint"
-                },
-                {
-                    "name": "kool-npmrc",
-                    "path": "template/kool-npmrc"
-                },
-                {
-                    "name": "root-npmrc",
-                    "path": "template/root-npmrc"
                 }
             ]
         },
@@ -65,14 +49,6 @@
                 {
                     "name": "entrypoint",
                     "path": "template/entrypoint"
-                },
-                {
-                    "name": "kool-npmrc",
-                    "path": "template/kool-npmrc"
-                },
-                {
-                    "name": "root-npmrc",
-                    "path": "template/root-npmrc"
                 }
             ]
         }

--- a/template/Dockerfile.blade.php
+++ b/template/Dockerfile.blade.php
@@ -20,13 +20,26 @@ RUN adduser -D -u 1337 kool && deluser --remove-home node \
         make \
         zlib-dev \
     && npm install -g pnpm \
+    # pnpm global settings live in ~/.config/pnpm/rc so npm does not warn on unknown keys in ~/.npmrc (npm 11+)
+    && mkdir -p /root/.config/pnpm /home/kool/.config/pnpm \
+    && printf '%s\n' \
+        'store-dir=/root/.pnpm-store' \
+        'package-import-method=copy' \
+        'shamefully-hoist=true' \
+        'scripts-prepend-node-path=true' \
+        > /root/.config/pnpm/rc \
+    && printf '%s\n' \
+        'store-dir=/home/kool/.pnpm-store' \
+        'package-import-method=copy' \
+        'shamefully-hoist=true' \
+        'scripts-prepend-node-path=true' \
+        > /home/kool/.config/pnpm/rc \
+    && chown -R kool:kool /home/kool/.config \
     && rm -rf rm -rf /root/.npm/* \
     # dockerize
     && curl -L https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-alpine-linux-amd64-v0.6.1.tar.gz | tar xz \
     && mv dockerize /usr/local/bin/dockerize
 
-COPY root-npmrc /root/.npmrc
-COPY --chown=kool:kool kool-npmrc /home/kool/.npmrc
 COPY entrypoint /entrypoint
 
 RUN chmod +x /entrypoint

--- a/template/kool-npmrc.blade.php
+++ b/template/kool-npmrc.blade.php
@@ -1,4 +1,0 @@
-scripts-prepend-node-path=true
-package-import-method=copy
-shamefully-hoist=true
-store-dir=/home/kool/.pnpm-store

--- a/template/root-npmrc.blade.php
+++ b/template/root-npmrc.blade.php
@@ -1,4 +1,0 @@
-scripts-prepend-node-path=true
-package-import-method=copy
-shamefully-hoist=true
-store-dir=/root/.pnpm-store


### PR DESCRIPTION
pnpm-only keys and deprecated npm options in ~/.npmrc caused npm to warn on every invocation. Write the same defaults to ~/.config/pnpm/rc for root and kool instead, and drop the generated npmrc templates from the fwd build.

Made-with: Cursor