### PR TITLE
ci: rotate buildx cache weekly so npm@latest actually refreshes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,16 +21,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Compute cache week
+        id: cachekey
+        run: echo "week=$(date -u +%Y-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: docker-buildx-${{ matrix.version }}-${{ github.sha }}
-          restore-keys: docker-buildx-${{ matrix.version }}-
+          key: docker-buildx-${{ matrix.version }}-${{ steps.cachekey.outputs.week }}-${{ github.sha }}
+          restore-keys: docker-buildx-${{ matrix.version }}-${{ steps.cachekey.outputs.week }}-
 
       - name: Build
         run: |
           docker buildx build \
+            --pull \
             --cache-from type=local,src=/tmp/.buildx-cache/${{ matrix.version }} \
             --cache-to type=local,dest=/tmp/.buildx-cache/${{ matrix.version }} \
             --output type=docker \


### PR DESCRIPTION
## Problem

`kooldev/node:24` (and the other tags) ship an outdated npm — currently **11.9.0**, below the **11.13.0** we need — even though the Dockerfile already does `RUN npm i --location=global npm@latest`.

`npm@latest` resolves at *build time*, and the weekly cron (`0 0 * * 0`) that's meant to keep images fresh never actually re-resolves it. The buildx layer cache is restored via a **prefix restore-key** (`docker-buildx-${version}-`) keyed on `${{ github.sha }}`. On the weekly cron, `master`'s sha is unchanged, so every layer — including `RUN npm i npm@latest` — is a cache hit and npm stays frozen until a code change alters the sha.

## Fix

Keep `npm@latest` (no version pinning, no Dockerfile/template change) and rotate the layer cache **once a week** so the existing cron does a genuine cold rebuild:

1. Add a `Compute cache week` step emitting an ISO week stamp (`date -u +%Y-%V`).
2. Fold `${week}` into both the cache `key` and `restore-keys`. Each new week → no restore-key match → cold build → `npm@latest` re-resolves. Intra-week pushes still hit the cache for fast incremental builds.
3. Add `--pull` to the buildx build so cold rebuilds also refresh the base `node:*-alpine` digest.

The key-*format* change (inserting `${week}`) also invalidates the old prefix match, so **merging this triggers a one-time cold rebuild** that refreshes npm to ≥11.13 immediately — no manual `workflow_dispatch` needed.

## Verification

- The existing `Tests` step already runs `npm -v`; after merge it should print ≥ 11.13.0.
- First post-merge run should report a cache **miss** for each version.

> Note: `24-nginx` is `FROM kooldev/node:24` and inherits npm from the published `:24`, so it lags by one build cycle (pre-existing, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)